### PR TITLE
Pin higher requests version for security

### DIFF
--- a/postr/reddit_postr.py
+++ b/postr/reddit_postr.py
@@ -76,10 +76,7 @@ class Reddit(ApiInterface):
 
     def get_user_likes(self) -> int:
         ''' This method returns the number of likes a user has total between link and client'''
-        return int(
-            self.client.user.me().comment_karma +
-            self.client.user.me().link_karma,
-        )
+        return int(self.client.user.me().comment_karma + self.client.user.me().link_karma)
 
     def get_user_followers(self, text: str) -> List[str]:
         ''' This method returns a list of all the people that

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ pytest==3.8.1
 pytest-asyncio
 PyTumblr==0.0.8
 PyYAML==3.13
-requests==2.19.1
+requests==2.20.0
 requests-oauthlib==1.0.0
 six==1.11.0
 smmap2==2.0.4


### PR DESCRIPTION
The Requests package before 2.20.0 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.

https://nvd.nist.gov/vuln/detail/CVE-2018-18074